### PR TITLE
avoid protected branch on release

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: main
+          token: ${{ secrets.TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2


### PR DESCRIPTION
I added a token in the repository secrets to bypass the protected branch

closes #62 