### PR TITLE
Adding support of Jacoco in Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,6 @@
             <goals>
               <goal>report</goal>
             </goals>
-            <configuration>
-              <outputDirectory>${project.target.directory}/jacoco</outputDirectory>
-            </configuration>
           </execution>
           <execution>
             <id>check</id>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,64 @@
           <quiet>true</quiet>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.8</version>
+        <configuration>
+          <skip>false</skip>
+          <check/>
+          <rules>
+            <rule>
+              <element>CLASS</element>
+              <excludes>
+                    <exclude>*Test</exclude>
+              </excludes>
+              <limits>
+                    <limit>
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.00</minimum>
+                    </limit>
+              </limits>
+            </rule>
+          </rules>
+        </configuration>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.target.directory}/jacoco</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <check>
+                <instructionRatio>100</instructionRatio>
+                <branchRatio>95</branchRatio>
+                <lineRatio>90</lineRatio>
+                <methodRatio>90</methodRatio>
+                <classRatio>90</classRatio>
+              </check>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -102,6 +160,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.8.2</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.8.8</version>
+      <type>maven-plugin</type>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
I added the dependency of Jacoco in the `pom.xml`.
When you run `mvn test`, jacoco will do his job ^^
After that, if you launch the command `mvn jacoco:report`, a folder `target/site/jacoco` will be created containing a whole bunch of stuff indicating the code coverage of our tests.
There will be also an `index.html` file to see easily all the statistics.

Sources : 
- https://www.jacoco.org/jacoco/trunk/doc/maven.html
- https://www.jacoco.org/jacoco/trunk/doc/report-mojo.html